### PR TITLE
README change and resolve deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # is-research-service
 
-[![Build Status](https://travis-ci.com/NYPL/is-research-service.svg?branch=master)](https://travis-ci.com/NYPL/is-research-service) 
+[![Build Status](https://travis-ci.com/NYPL/is-research-service.svg?branch=master)](https://travis-ci.com/NYPL/is-research-service)
 
 This is a Ruby app deployed as an AWS Lambda behind API Gateway to serve:
 
 ``GET /api/v0.1/items/{nyplSource}/{id}/is-research``
-
-The `is-research-layer` directory corresponds to the Lambda Layer used for the forthcoming `SubjectHeadingPoster`. Instructions for updating and redeploying the layer are below.
 
 The business logic implemented in this code base for determining if an item or bib is research or circulating is documented here:
 
@@ -33,20 +31,10 @@ All config is in `sam.[ENVIRONMENT].yml` templates, encrypted as necessary.
  * Merge `qa` > `master`
  * Tag version bump in `master`
 
-### Updating Lambda Layer
- * Once any change to the files within `is-research-layer` have been developed and reviewed, from the main directory, run
-
- ``zip -r is-research-layer is-research-layer/*``
-
- * Create a new version of the layer from the AWS console under Lambda service.
- * Update Lambdas that pull in this layer by changing the version number in the SAM template.
-  * Lambdas using the "isResearchLayer":
-    * `SubjectHeadingPoster-qa` (forthcoming)
-
 ### Running Events Locally
 The following will invoke the lambda against various mock events. Replace `[event]` with one of the mock events listed below.
 
-``sam local invoke --event [event] --region us-east-1 --template sam.local.yml --profile [aws profile]``
+``sam local invoke --event events/[event] --region us-east-1 --template sam.local.yml --profile [aws profile]``
 
 #### Events
  * `event-bib_is_research_true.json`

--- a/lib/bib.rb
+++ b/lib/bib.rb
@@ -4,7 +4,7 @@ require_relative 'item'
 
 class Bib < MarcRecord
   def is_research?
-    result = FALSE
+    result = false
     begin
       result = is_partner? || is_mixed_bib? || first_item_is_research?
     rescue NotFoundError => e


### PR DESCRIPTION
Just a small PR to remove reference to Lambda layer in the README and fix the casing of false.
From the Cloudwatch logs:
`warning: constant ::FALSE is deprecated`