### PR TITLE
Fix logic and tests for bib with no items

### DIFF
--- a/lib/bib.rb
+++ b/lib/bib.rb
@@ -10,6 +10,8 @@ class Bib < MarcRecord
     rescue NotFoundError => e
       bib = get_platform_api_data bib_path
       raise DeletedError if bib["deleted"]
+      # Only a research bib would exist with no items
+      result = true
     end
 
     $logger.debug "Evaluating is-research for bib #{nypl_source} #{id}: #{result}", @log_data

--- a/spec/fixtures/bib_12345678.json
+++ b/spec/fixtures/bib_12345678.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "66666",
+    "id": "12345678",
     "nyplSource": "recap-pul",
     "nyplType": "bib",
     "updatedDate": "2017-10-12T22:54:24-04:00",

--- a/spec/models/bib_spec.rb
+++ b/spec/models/bib_spec.rb
@@ -19,12 +19,12 @@ describe Bib do
   before(:each) do
     stub_request(:get, ENV['NYPL_CORE_S3_BASE_URL'] + "by_catalog_item_type.json")
     .to_return(status: 200, body: File.read("./spec/fixtures/by_catalog_item_type.json"))
-    
+
     stub_request(:get, ENV['NYPL_CORE_S3_BASE_URL'] + "by_sierra_location.json")
     .to_return(status: 200, body: File.read("./spec/fixtures/by_sierra_location.json"))
-    
+
     stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
-    
+
     $platform_api = PlatformApiClient.new
     $nypl_core = NyplCore.new
     $logger = NyplLogFormatter.new(STDOUT, level: ENV['LOG_LEVEL'] || 'info')
@@ -43,12 +43,13 @@ describe Bib do
       )
     end
 
+    # this end point returns 404 for bib with no items
     stub_request(:get,
-      "#{ENV['PLATFORM_API_BASE_URL']}bibs/recap-pul/66666/items").to_return(status: 404, body: File.read("./spec/fixtures/sierra_404.json")
+      "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/12345678/items").to_return(status: 404, body: File.read("./spec/fixtures/sierra_404.json")
     )
 
     stub_request(:get,
-      "#{ENV['PLATFORM_API_BASE_URL']}bibs/recap-pul/66666").to_return(status: 200, body: File.read("./spec/fixtures/bib_66666.json")
+      "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/12345678").to_return(status: 200, body: File.read("./spec/fixtures/bib_12345678.json")
     )
 
     stub_request(:get,
@@ -68,13 +69,13 @@ describe Bib do
     end
 
     it "should declare a bib with 0 items as research" do
-      test_bib = test_bibs[1]
-      expect(test_bib[:bib].is_research?).to eq(test_bib[:result])
+      test_bib = Bib.new("sierra-nypl", "12345678")
+      expect(test_bib.is_research?).to eq(true)
     end
 
     it "should declare a bib with at least one research item as research" do
-      test_bib = Bib.new('recap-pul', '66666')
-      expect(test_bib.is_research?).to eq(true)
+      test_bib = test_bibs[1]
+      expect(test_bib[:bib].is_research?).to eq(true)
     end
 
     it "should throw DeletedError for a deleted bib record" do


### PR DESCRIPTION
I found this bug while investigating SCC-2396. Seems like there were a two issues with the test coverage here that I am fixing now:
1) Since the last round of changes, the bib for this test needs to be an NYPL item
2) Just a careless error in which two test bibs were swapped. So, I made the test suite a little more explicit.