### PR TITLE
Upgrade to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.5
+  - 2.7
 before_install:
 - gem update --system
 - gem install bundler
@@ -16,7 +16,7 @@ deploy:
   description: A small service for determining if an item or bib is research
   region: us-east-1
   role: arn:aws:iam::224280085904:role/lambda_basic_execution
-  runtime: ruby2.5
+  runtime: ruby2.7
   module_name: app
   handler_name: handle_event
   environment_variables:
@@ -35,7 +35,7 @@ deploy:
   description: A small service for determining if an item or bib is research
   region: us-east-1
   role: arn:aws:iam::946183545209:role/lambda-full-access
-  runtime: ruby2.5
+  runtime: ruby2.7
   module_name: app
   handler_name: handle_event
   environment_variables:
@@ -54,7 +54,7 @@ deploy:
   description: A small service for determining if an item or bib is research
   region: us-east-1
   role: arn:aws:iam::946183545209:role/lambda-full-access
-  runtime: ruby2.5
+  runtime: ruby2.7
   module_name: app
   handler_name: handle_event
   environment_variables:

--- a/sam.dev.yml
+++ b/sam.dev.yml
@@ -13,7 +13,7 @@ Resources:
           Properties:
             Path: /api/v0.1/{type}/{nyplSource}/{id}/is-research
             Method: get
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Timeout: 10
       Environment:
         Variables:

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -13,7 +13,7 @@ Resources:
           Properties:
             Path: /api/v0.1/{type}/{nyplSource}/{id}/is-research
             Method: get
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Timeout: 10
       Environment:
         Variables:

--- a/sam.production.yml
+++ b/sam.production.yml
@@ -13,7 +13,7 @@ Resources:
           Properties:
             Path: /api/v0.1/{type}/{nyplSource}/{id}/is-research
             Method: get
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Timeout: 10
       Environment:
         Variables:

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -13,7 +13,7 @@ Resources:
           Properties:
             Path: /api/v0.1/{type}/{nyplSource}/{id}/is-research
             Method: get
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Timeout: 10
       Environment:
         Variables:


### PR DESCRIPTION
Upgrades to 2.7. This is for scc-2724. We are trying to upgrade all our lambdas in anticipation of AWS dropping support for Ruby 2.5. 