### PR TITLE
Include swagger files in packaging

### DIFF
--- a/provisioning/package.sh
+++ b/provisioning/package.sh
@@ -15,4 +15,4 @@ bundle install
 bundle install --deployment
 
 # Move required application files into build:
-zip -r build/lambda-deployment.zip app.rb lib vendor
+zip -r build/lambda-deployment.zip app.rb lib vendor swagger.json swagger.yaml


### PR DESCRIPTION
This was causing a problem with the `/docs` endpoint.